### PR TITLE
[Feature]: Elasticsearch backend support document routing

### DIFF
--- a/internal/storage/elasticsearch/client.go
+++ b/internal/storage/elasticsearch/client.go
@@ -50,6 +50,7 @@ type TemplateCreateService interface {
 type IndexService interface {
 	Index(index string) IndexService
 	Type(typ string) IndexService
+	OpType(opTyp string) IndexService
 	Id(id string) IndexService
 	BodyJson(body any) IndexService
 	Add()

--- a/internal/storage/elasticsearch/dbmodel/model.go
+++ b/internal/storage/elasticsearch/dbmodel/model.go
@@ -60,6 +60,9 @@ type Span struct {
 	Tag     map[string]any `json:"tag,omitempty"`
 	Logs    []Log          `json:"logs"`
 	Process Process        `json:"process,omitempty"`
+
+	// data stream index require @timestamp field
+	Timestamp time.Time `json:"@timestamp"`
 }
 
 // Reference is a reference from one span to another
@@ -94,6 +97,9 @@ type KeyValue struct {
 type Service struct {
 	ServiceName   string `json:"serviceName"`
 	OperationName string `json:"operationName"`
+
+	// data stream index require @timestamp field
+	Timestamp time.Time `json:"@timestamp"`
 }
 
 // Operation is the struct for span operation properties.

--- a/internal/storage/elasticsearch/mocks/mocks.go
+++ b/internal/storage/elasticsearch/mocks/mocks.go
@@ -1177,6 +1177,59 @@ func (_c *IndexService_Index_Call) RunAndReturn(run func(index string) elasticse
 	return _c
 }
 
+// OpType provides a mock function for the type IndexService
+func (_mock *IndexService) OpType(opTyp string) elasticsearch.IndexService {
+	ret := _mock.Called(opTyp)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OpType")
+	}
+
+	var r0 elasticsearch.IndexService
+	if returnFunc, ok := ret.Get(0).(func(string) elasticsearch.IndexService); ok {
+		r0 = returnFunc(opTyp)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(elasticsearch.IndexService)
+		}
+	}
+	return r0
+}
+
+// IndexService_OpType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OpType'
+type IndexService_OpType_Call struct {
+	*mock.Call
+}
+
+// OpType is a helper method to define mock.On call
+//   - opTyp string
+func (_e *IndexService_Expecter) OpType(opTyp interface{}) *IndexService_OpType_Call {
+	return &IndexService_OpType_Call{Call: _e.mock.On("OpType", opTyp)}
+}
+
+func (_c *IndexService_OpType_Call) Run(run func(opTyp string)) *IndexService_OpType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *IndexService_OpType_Call) Return(indexService elasticsearch.IndexService) *IndexService_OpType_Call {
+	_c.Call.Return(indexService)
+	return _c
+}
+
+func (_c *IndexService_OpType_Call) RunAndReturn(run func(opTyp string) elasticsearch.IndexService) *IndexService_OpType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Type provides a mock function for the type IndexService
 func (_mock *IndexService) Type(typ string) elasticsearch.IndexService {
 	ret := _mock.Called(typ)

--- a/internal/storage/elasticsearch/wrapper/wrapper.go
+++ b/internal/storage/elasticsearch/wrapper/wrapper.go
@@ -228,6 +228,14 @@ func (i IndexServiceWrapper) Type(typ string) es.IndexService {
 	return WrapESIndexService(i.bulkIndexReq.Type(typ), i.bulkService, i.esVersion)
 }
 
+// OpType calls this function to internal service.
+func (i IndexServiceWrapper) OpType(opType string) es.IndexService {
+	if opType == "" {
+		opType = "index"
+	}
+	return WrapESIndexService(i.bulkIndexReq.OpType(opType), i.bulkService, i.esVersion)
+}
+
 // Add adds the request to bulk service
 func (i IndexServiceWrapper) Add() {
 	i.bulkService.Add(i.bulkIndexReq)

--- a/internal/storage/v1/elasticsearch/factory.go
+++ b/internal/storage/v1/elasticsearch/factory.go
@@ -114,10 +114,16 @@ func (f *FactoryBase) GetSpanReaderParams() esSpanStore.SpanReaderParams {
 		ServiceIndex:        f.config.Indices.Services,
 		TagDotReplacement:   f.config.Tags.DotReplacement,
 		UseReadWriteAliases: f.config.UseReadWriteAliases,
-		ReadAliasSuffix:     f.config.ReadAliasSuffix,
-		RemoteReadClusters:  f.config.RemoteReadClusters,
-		Logger:              f.logger,
-		Tracer:              f.tracer.Tracer("esSpanStore.SpanReader"),
+		UseIndexSuffixTemplate: func() bool {
+			if f.config.Indices.IndexSuffixTemplate != "" {
+				return true
+			}
+			return false
+		}(),
+		ReadAliasSuffix:    f.config.ReadAliasSuffix,
+		RemoteReadClusters: f.config.RemoteReadClusters,
+		Logger:             f.logger,
+		Tracer:             f.tracer.Tracer("esSpanStore.SpanReader"),
 	}
 }
 
@@ -126,6 +132,7 @@ func (f *FactoryBase) GetSpanWriterParams() esSpanStore.SpanWriterParams {
 	return esSpanStore.SpanWriterParams{
 		Client:              f.getClient,
 		IndexPrefix:         f.config.Indices.IndexPrefix,
+		IndexSuffixTemplate: f.config.Indices.IndexSuffixTemplate,
 		SpanIndex:           f.config.Indices.Spans,
 		ServiceIndex:        f.config.Indices.Services,
 		AllTagsAsFields:     f.config.Tags.AllAsFields,

--- a/internal/storage/v1/elasticsearch/spanstore/mocks/mocks.go
+++ b/internal/storage/v1/elasticsearch/spanstore/mocks/mocks.go
@@ -493,3 +493,55 @@ func (_c *CoreSpanWriter_WriteSpan_Call) RunAndReturn(run func(spanStartTime tim
 	_c.Run(run)
 	return _c
 }
+
+// WriteSpanWithDynamicSuffix provides a mock function for the type CoreSpanWriter
+func (_mock *CoreSpanWriter) WriteSpanWithDynamicSuffix(spanStartTime time.Time, span *dbmodel.Span, dynamicIndexSuffix string) {
+	_mock.Called(spanStartTime, span, dynamicIndexSuffix)
+	return
+}
+
+// CoreSpanWriter_WriteSpanWithDynamicSuffix_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WriteSpanWithDynamicSuffix'
+type CoreSpanWriter_WriteSpanWithDynamicSuffix_Call struct {
+	*mock.Call
+}
+
+// WriteSpanWithDynamicSuffix is a helper method to define mock.On call
+//   - spanStartTime time.Time
+//   - span *dbmodel.Span
+//   - dynamicIndexSuffix string
+func (_e *CoreSpanWriter_Expecter) WriteSpanWithDynamicSuffix(spanStartTime interface{}, span interface{}, dynamicIndexSuffix interface{}) *CoreSpanWriter_WriteSpanWithDynamicSuffix_Call {
+	return &CoreSpanWriter_WriteSpanWithDynamicSuffix_Call{Call: _e.mock.On("WriteSpanWithDynamicSuffix", spanStartTime, span, dynamicIndexSuffix)}
+}
+
+func (_c *CoreSpanWriter_WriteSpanWithDynamicSuffix_Call) Run(run func(spanStartTime time.Time, span *dbmodel.Span, dynamicIndexSuffix string)) *CoreSpanWriter_WriteSpanWithDynamicSuffix_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 time.Time
+		if args[0] != nil {
+			arg0 = args[0].(time.Time)
+		}
+		var arg1 *dbmodel.Span
+		if args[1] != nil {
+			arg1 = args[1].(*dbmodel.Span)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *CoreSpanWriter_WriteSpanWithDynamicSuffix_Call) Return() *CoreSpanWriter_WriteSpanWithDynamicSuffix_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *CoreSpanWriter_WriteSpanWithDynamicSuffix_Call) RunAndReturn(run func(spanStartTime time.Time, span *dbmodel.Span, dynamicIndexSuffix string)) *CoreSpanWriter_WriteSpanWithDynamicSuffix_Call {
+	_c.Run(run)
+	return _c
+}

--- a/internal/storage/v2/elasticsearch/factory.go
+++ b/internal/storage/v2/elasticsearch/factory.go
@@ -46,7 +46,11 @@ func (f *Factory) CreateTraceReader() (tracestore.Reader, error) {
 
 func (f *Factory) CreateTraceWriter() (tracestore.Writer, error) {
 	params := f.coreFactory.GetSpanWriterParams()
-	wr := v2tracestore.NewTraceWriter(params)
+	var wr tracestore.Writer
+	wr = v2tracestore.NewTraceWriter(params)
+	if params.IndexSuffixTemplate != "" {
+		wr = v2tracestore.NewTraceDynamicIndexWriter(params)
+	}
 	return wr, nil
 }
 

--- a/internal/storage/v2/elasticsearch/tracestore/dynamic_index.go
+++ b/internal/storage/v2/elasticsearch/tracestore/dynamic_index.go
@@ -1,0 +1,66 @@
+package tracestore
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/dbmodel"
+)
+
+const unrouted = "unrouted"
+
+func parseDynamicKeys(template string) []string {
+	re := regexp.MustCompile(`\{\{(.*?)\}\}`)
+	matches := re.FindAllStringSubmatch(template, -1)
+
+	keyMap := make(map[string]struct{})
+	for _, match := range matches {
+		if len(match) > 1 {
+			keyMap[strings.TrimSpace(match[1])] = struct{}{}
+		}
+	}
+	var keys []string
+	for k := range keyMap {
+		keys = append(keys, k)
+	}
+
+	return keys
+}
+
+func buildIndexSuffix(span *dbmodel.Span, dynamicKeys []string, template string) string {
+	if len(dynamicKeys) == 0 {
+		return template
+	}
+
+	data := make(map[string]string, len(dynamicKeys))
+	for _, target := range dynamicKeys {
+		value := unrouted
+		for _, tag := range span.Process.Tags {
+			if tag.Key == target && tag.Type == dbmodel.StringType {
+				value = tag.Value.(string)
+				break
+			}
+		}
+
+		if value == unrouted {
+			for _, tag := range span.Tags {
+				if tag.Key == target && tag.Type == dbmodel.StringType {
+					value = tag.Value.(string)
+					break
+				}
+			}
+		}
+
+		data[target] = value
+	}
+
+	return applyTemplate(template, data)
+}
+
+func applyTemplate(template string, data map[string]string) string {
+	for k, v := range data {
+		template = regexp.MustCompile(`\{\{`+regexp.QuoteMeta(k)+`\}\}`).ReplaceAllString(template, v)
+	}
+
+	return template
+}

--- a/internal/storage/v2/elasticsearch/tracestore/dynamic_index_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/dynamic_index_test.go
@@ -1,0 +1,111 @@
+package tracestore
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDynamicKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "Multiple Keys",
+			input:    "{{k8s.cluster.name}}-{{k8s.namespace.name}}",
+			expected: []string{"k8s.cluster.name", "k8s.namespace.name"},
+		},
+		{
+			name:     "Multiple same Keys",
+			input:    "{{k8s.cluster.name}}-{{k8s.cluster.name}}",
+			expected: []string{"k8s.cluster.name"},
+		},
+		{
+			name:     "Single Key",
+			input:    "{{k8s.cluster.name}}",
+			expected: []string{"k8s.cluster.name"},
+		},
+		{
+			name:     "No Keys",
+			input:    "cluster-1",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDynamicKeys(tt.input)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestBuildIndexSuffix(t *testing.T) {
+	tests := []struct {
+		name        string
+		dynamicKeys []string
+		template    string
+		indexSuffix string
+	}{
+		{
+			name:        "No Keys",
+			dynamicKeys: nil,
+			template:    "cluster",
+			indexSuffix: "cluster",
+		},
+		{
+			name:        "Single Key",
+			dynamicKeys: []string{"k8s.cluster.name"},
+			template:    "{{k8s.cluster.name}}",
+			indexSuffix: "cluster-1",
+		},
+		{
+			name:        "Multiple Keys",
+			dynamicKeys: []string{"k8s.cluster.name", "k8s.namespace.name"},
+			template:    "{{k8s.cluster.name}}-{{k8s.namespace.name}}",
+			indexSuffix: "cluster-1-namespace-1",
+		},
+		{
+			name:        "Multiple same Keys",
+			dynamicKeys: []string{"k8s.cluster.name"},
+			template:    "{{k8s.cluster.name}}-{{k8s.cluster.name}}",
+			indexSuffix: "cluster-1-cluster-1",
+		},
+		{
+			name:        "not exist Keys",
+			dynamicKeys: []string{"not.exist.key1", "not.exist.key2"},
+			template:    "${not.exist.key1}-${not.exist.key2}",
+			indexSuffix: "unrouted-unrouted",
+		},
+		// TODO test sort,test attribute type not support
+	}
+
+	traces := ptrace.NewTraces()
+	rSpans := traces.ResourceSpans().AppendEmpty()
+	rSpans.Resource().Attributes().PutStr("k8s.cluster.name", "cluster-1")
+	rSpans.Resource().Attributes().PutStr("k8s.namespace.name", "namespace-1")
+	sSpans := rSpans.ScopeSpans().AppendEmpty()
+	span := sSpans.Spans().AppendEmpty()
+
+	spanID := pcommon.NewSpanIDEmpty()
+	spanID[5] = 5 // 0000000000050000
+	span.SetSpanID(spanID)
+
+	traceID := pcommon.NewTraceIDEmpty()
+	traceID[15] = 1 // 00000000000000000000000000000001
+	span.SetTraceID(traceID)
+	dbSpans := ToDBModel(traces)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := buildIndexSuffix(&dbSpans[0], tt.dynamicKeys, tt.template)
+			assert.Equal(t, tt.indexSuffix, actual)
+		})
+	}
+
+}

--- a/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
+++ b/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
@@ -141,6 +141,7 @@ func spanToDbSpan(span ptrace.Span, libraryTags pcommon.InstrumentationScope, pr
 		Logs:            spanEventsToDbSpanLogs(span.Events()),
 		Process:         process,
 		Flags:           span.Flags(),
+		Timestamp:       startTime,
 	}
 }
 


### PR DESCRIPTION
Adding a new configuration parameter: index_suffix_template.

usage limit:
- `use_aliases` must be set false
-  `date_layout` musit be empty
- you need to use [Data streams](https://www.elastic.co/docs/manage-data/data-store/data-streams) to manage the dynamic index

example config:
```yaml
extensions:
  jaeger_storage:
    backends:
      storage/elasticsearch:
        elasticsearch:
          server_urls:
            - http://localhost:9200
          auth:
            basic:
              username: elastic
              password: DkIedPPSCb
          bulk_processing:
            max_bytes: 5000000
            workers: 10
            max_actions: 1000
            flush_interval: 200ms
          tags_as_fields:
            dot_replacement: "@"
            include: "k8s.cluster.id,k8s.namespace.name"
          create_mappings: false
          use_aliases: false
          use_ilm: false
          indices:
            index_prefix: "insight"
            index_suffix_template: "{{k8s.cluster.name}}-{{k8s.namespace.name}}"
            spans:
              date_layout: ""
            services:
              date_layout: ""
```

You can find a data stream ILM policy and index template in below
[data-stream-sheet.txt](https://github.com/user-attachments/files/20739138/data-stream-sheet.txt)
